### PR TITLE
Add gtest for library and rostest for nodes

### DIFF
--- a/ros/src/models/chrono/ros_chrono/CMakeLists.txt
+++ b/ros/src/models/chrono/ros_chrono/CMakeLists.txt
@@ -323,3 +323,16 @@ target_link_libraries(velocity_controller
 
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
+
+#####################
+# g Tests and rostest
+#####################
+# New added for rostest
+if(CATKIN_ENABLE_TESTING)
+  message("\n\nGoing to build the ros_chrono tests!\n\n")
+  find_package(rostest REQUIRED)
+  # You can add arbitrary new test files in the end of add_rostest_gtest
+  add_rostest(launch/steering.launch) #perhaps
+
+endif()
+# End rostest

--- a/ros/src/models/chrono/ros_chrono/launch/steering.launch
+++ b/ros/src/models/chrono/ros_chrono/launch/steering.launch
@@ -10,5 +10,8 @@
   <rosparam command="load" file="$(arg chrono_params_path)"/>
  
   <node name="Reference" pkg="traj_gen_chrono" type="traj_gen_chrono"/>
+  <test test-name="Reference_test" pkg="traj_gen_chrono" type="traj_gen_chrono"/>
+
   <node name="Chronode" pkg="ros_chrono" type="steering_controller" cwd="node" />
+  <test test-name="Chronode_test" pkg="ros_chrono" type="steering_controller" />
 </launch>

--- a/ros/src/models/chrono/ros_chrono/package.xml
+++ b/ros/src/models/chrono/ros_chrono/package.xml
@@ -49,6 +49,11 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- New added part for rostest, start -->
+  <depend>rostest</depend> 
+  <depend>genmsg</depend>
+  <!-- New added part for rostest, end -->
+
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>

--- a/ros/src/system/CMakeLists.txt
+++ b/ros/src/system/CMakeLists.txt
@@ -19,3 +19,19 @@ add_executable(system_shutdown src/system_shutdown.cpp)
 target_link_libraries(system_shutdown ${catkin_LIBRARIES})
 
 add_dependencies(system_shutdown ${catkin_EXPORTED_TARGETS})
+
+#####################
+# g Tests and rostest
+#####################
+# New added for rostest
+if(CATKIN_ENABLE_TESTING)
+	message("\n\nGoing to build the tests!\n\n")
+	find_package(rostest REQUIRED)
+	find_package(gtest)
+	# You can add arbitrary new test files in the end of add_rostest_gtest
+	add_rostest_gtest(test_mynode test/gtest_launch.launch src/test/mytest.cpp)
+	add_rostest(launch/demoA.launch) #perhaps
+
+	target_link_libraries(test_mynode ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+endif()
+# End rostest and gtest

--- a/ros/src/system/launch/demoA.launch
+++ b/ros/src/system/launch/demoA.launch
@@ -39,11 +39,14 @@
   <node name="system_shutdown" pkg="system" type="system_shutdown" output="screen" required="true">
      <rosparam file="$(arg system_params_path)" command="load"/>
   </node>
+  <test test-name="system_shutdown" pkg="system" type="system_shutdown" />
 
   <!-- initialize system -->
   <node name="bootstrap" pkg="system" type="bootstrap.jl" output="screen"/>
+  <test test-name="bootstrap" pkg="system" type="bootstrap.jl" />
 
   <!-- unpause Gazebo -->
   <node name="unpause_gazebo" pkg="vehicle_description" type="unpause.jl" output="screen"/>
+  <test test-name="unpause_gazebo" pkg="vehicle_description" type="unpause.jl" />
 
 </launch>

--- a/ros/src/system/package.xml
+++ b/ros/src/system/package.xml
@@ -21,6 +21,12 @@
   <depend>roscpp</depend>
   <depend>rospy</depend>
 
+  <!-- New added part for rostest, start -->
+  <depend>rostest</depend> 
+  <depend>genmsg</depend>
+  <depend>std_msgs</depend>
+  <!-- New added part for rostest, end -->
+
   <exec_depend>nloptcontrol_planner</exec_depend>
   <exec_depend>vehicle_description</exec_depend>
   <exec_depend>obstacle_detector</exec_depend>

--- a/ros/src/system/src/test/mytest.cpp
+++ b/ros/src/system/src/test/mytest.cpp
@@ -1,0 +1,18 @@
+#include "ros/ros.h"
+#include <gtest/gtest.h>
+
+
+TEST(MAVsTester, basicTest){
+
+  int a = 1;
+  int b = 2;
+  int c = a+b;
+  std::cout << "\n\n\nThis comes form inside of one test case\n\n\n";
+
+  EXPECT_EQ(c, 3);
+}
+
+int main(int argc, char** argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/ros/src/system/test/demo_test.test
+++ b/ros/src/system/test/demo_test.test
@@ -1,0 +1,3 @@
+<launch> 
+ <test test-name="demoA" pkg="system" type="testA.py" />
+</launch>

--- a/ros/src/system/test/gtest_launch.launch
+++ b/ros/src/system/test/gtest_launch.launch
@@ -1,0 +1,3 @@
+<launch>
+ <test test-name="test_mynode" pkg="system" type="test_mynode" />
+</launch>


### PR DESCRIPTION
This merge is a first version for demo test. I haven't finished the travis file's edit. I think I need to add whatever command I type in terminal to start the test in travis file.
Following are the command needed to run the test:

1.    sudo sh build.sh
2.    sh run.sh
3.    cd MAVs/ros
4.    catkin_make run_tests

The test is finished by rostest and gtest as shown below.
gtest tests the new function added to library, where the test folder is in system/src/test.
rostest tests nodes in launch file, where the test files are directly added to launch file such as demoA.launch. The test node is very similar to regular node. In this merge, I take demoA.launch as example. I have added test node after each regular node: .
To activate above tests, we need to add several terms to cmakefile.txt to make each launch file. This should be a conditional term as shown below:

#####################
# g Tests and rostest
#####################
# New added for rostest
if(CATKIN_ENABLE_TESTING)
	message("\n\nGoing to build the tests!\n\n")
	find_package(rostest REQUIRED)
	find_package(gtest)
	# You can add arbitrary new test files in the end of add_rostest_gtest
	add_rostest_gtest(test_mynode test/gtest_launch.launch src/test/mytest.cpp)
	add_rostest(launch/demoA.launch) 

	target_link_libraries(test_mynode ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
endif()
# End rostest and `gtest`

![image](https://user-images.githubusercontent.com/29248149/47973728-f8831080-e073-11e8-894f-c874f9f57dce.png)

At last, since I'm still not very clear about how to find the right answer for each test node, every node I have in demoA.launch and steering.launch will fail the node test. I will study on this problem.